### PR TITLE
Make fixDesc leave `&amp;` and `&quot;` alone

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -1121,9 +1121,9 @@ function fixDesc($desc, $specials = 0)
             if (strncasecmp($therest, "lt;", 3) == 0
                 || strncasecmp($therest, "gt;", 3) == 0) {
                 $ofs += 3;
-            } else if (strncasecmp($desc, "amp;", 4) == 0) {
+            } else if (strncasecmp($therest, "amp;", 4) == 0) {
                 $ofs += 4;
-            } else if (strncasecmp($desc, "quot;", 5) == 0) {
+            } else if (strncasecmp($therest, "quot;", 5) == 0) {
                 $ofs += 5;
             } else {
                 // not recognized - make it an explicit &amp;


### PR DESCRIPTION
The code indicates that fixDesc intends to leave `&amp;` and `&quot;` alone, but the comparisons it was running were incorrect; it was checking to see if the entire description starts with `quot;` or `amp;` instead of `$therest` of the token after the `&`.