### PR TITLE
basic parsedown verifier

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -2905,45 +2905,18 @@ else if (isset($_REQUEST['deletenews'])) {
     for ($i = 0; $i < $count; $i++) {
         $rec = mysql_fetch_array($result, MYSQL_ASSOC);
         $raw = $rec['review'];
-        // a bunch of reviews have random \r characters strewn about.
-        // Legacy treats these as spaces; Parsedown treats them as line breaks.
-        $removedCarriageReturns = str_replace("\r", " ", $raw);
-        $reviewMarkdown = fixDesc($parsedown->text($removedCarriageReturns), FixDescSpoiler);
+        $reviewMarkdown = fixDesc($parsedown->line($raw), FixDescSpoiler);
         $reviewLegacy = fixDesc($rec['review'], FixDescSpoiler);
         echo json_encode(["id" => $rec['id'], "gameid" => $rec['gameid'], "raw" => $rec['review'], "before" => $reviewLegacy, "after" => $reviewMarkdown]) . ",\n";
     }
     echo "];</script>\n";
     echo "<script nonce='$nonce'>
-    function normalize(html) {
-        const div = document.createElement('div');
-        div.innerHTML = html;
-        for (let i = div.childNodes.length - 1; i >= 0; i--) {
-            trimTextNodes(div.childNodes[i]);
-        }
-        // remove empty p tags
-        [...div.querySelectorAll('p')].filter(p => p.childNodes.length === 0).forEach(p => p.remove());
-        return div.innerHTML.replaceAll('<br><br>', '</p><p>');
-    }
-    function trimTextNodes(node) {
-        if (node.nodeType === Node.TEXT_NODE) {
-            const originalValue = node.nodeValue;
-            const trimmedValue = originalValue.replace(/\s+/g, ' ').trim();
-
-            if (originalValue !== trimmedValue) {
-                node.nodeValue = trimmedValue;
-            }
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            for (let i = node.childNodes.length - 1; i >= 0; i--) {
-                trimTextNodes(node.childNodes[i]);
-            }
-        }
-    }
     let matches = 0;
     window.mismatches = [];
     for (let i = 0; i < window.reviews.length; i++) {
         const review = window.reviews[i];
-        let before = normalize('<p>' + review.before);
-        let after = normalize(review.after);
+        let before = review.before
+        let after = review.after;
         if (before == after) {
             matches++;
         } else {

--- a/www/adminops
+++ b/www/adminops
@@ -2902,12 +2902,20 @@ else if (isset($_REQUEST['deletenews'])) {
     echo "<p>Count: $count</p>";
     $output = [];
     global $nonce;
+    // fixDesc assigns each spoiler a unique id; we don't want that
+    function normalizeSpoiler($text) {
+        $output = preg_replace("/a_spoiler\d+/", "", $text);
+        $output = preg_replace("/s_spoiler\d+/", "", $output);
+        $output = preg_replace("/data-num='\\d+'/", "", $output);
+        $output = preg_replace("/<script [\\s\\S]*<\\/script>/", "", $output);
+        return $output;
+    }
     echo "<script nonce='$nonce'>window.reviews = [\n";
     for ($i = 0; $i < $count; $i++) {
         $rec = mysql_fetch_array($result, MYSQL_ASSOC);
         $raw = $rec['review'];
-        $reviewMarkdown = fixDesc($parsedown->line($raw), FixDescSpoiler);
-        $reviewLegacy = fixDesc($rec['review'], FixDescSpoiler);
+        $reviewMarkdown = normalizeSpoiler(fixDesc($parsedown->line($raw), FixDescSpoiler));
+        $reviewLegacy = normalizeSpoiler(fixDesc($rec['review'], FixDescSpoiler));
         echo json_encode(["id" => $rec['id'], "gameid" => $rec['gameid'], "raw" => $rec['review'], "before" => $reviewLegacy, "after" => $reviewMarkdown]) . ",\n";
     }
     echo "];</script>\n";

--- a/www/adminops
+++ b/www/adminops
@@ -11,6 +11,7 @@ include_once "pagetpl.php";
 include_once "useractivation.php";
 
 include_once "dbconnect.php";
+require_once "vendor/autoload.php";
 $db = dbConnect();
 
 // assume no privileges
@@ -2892,6 +2893,68 @@ else if (isset($_REQUEST['deletenews'])) {
     }
 
     echo "</table>";
+} else if (isset($_REQUEST['markdownTest'])) {
+    $parsedown = new Parsedown();
+    $result = mysqli_execute_query($db, "select id, gameid, review from reviews where review is not null and special is null");
+    $matches = 0;
+    $count = mysql_num_rows($result);
+    echo "<p>Count: $count</p>";
+    $output = [];
+    global $nonce;
+    echo "<script nonce='$nonce'>window.reviews = [\n";
+    for ($i = 0; $i < $count; $i++) {
+        $rec = mysql_fetch_array($result, MYSQL_ASSOC);
+        $raw = $rec['review'];
+        // a bunch of reviews have random \r characters strewn about.
+        // Legacy treats these as spaces; Parsedown treats them as line breaks.
+        $removedCarriageReturns = str_replace("\r", " ", $raw);
+        $reviewMarkdown = fixDesc($parsedown->text($removedCarriageReturns), FixDescSpoiler);
+        $reviewLegacy = fixDesc($rec['review'], FixDescSpoiler);
+        echo json_encode(["id" => $rec['id'], "gameid" => $rec['gameid'], "raw" => $rec['review'], "before" => $reviewLegacy, "after" => $reviewMarkdown]) . ",\n";
+    }
+    echo "];</script>\n";
+    echo "<script nonce='$nonce'>
+    function normalize(html) {
+        const div = document.createElement('div');
+        div.innerHTML = html;
+        for (let i = div.childNodes.length - 1; i >= 0; i--) {
+            trimTextNodes(div.childNodes[i]);
+        }
+        // remove empty p tags
+        [...div.querySelectorAll('p')].filter(p => p.childNodes.length === 0).forEach(p => p.remove());
+        return div.innerHTML.replaceAll('<br><br>', '</p><p>');
+    }
+    function trimTextNodes(node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            const originalValue = node.nodeValue;
+            const trimmedValue = originalValue.replace(/\s+/g, ' ').trim();
+
+            if (originalValue !== trimmedValue) {
+                node.nodeValue = trimmedValue;
+            }
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            for (let i = node.childNodes.length - 1; i >= 0; i--) {
+                trimTextNodes(node.childNodes[i]);
+            }
+        }
+    }
+    let matches = 0;
+    window.mismatches = [];
+    for (let i = 0; i < window.reviews.length; i++) {
+        const review = window.reviews[i];
+        let before = normalize('<p>' + review.before);
+        let after = normalize(review.after);
+        if (before == after) {
+            matches++;
+        } else {
+            const mismatch = { i, review, befor: before, after };
+            console.log(mismatch);
+            window.mismatches.push(mismatch);
+        }
+    }
+    console.log({matches, count: window.reviews.length});
+    </script>";
+    echo "<p>done</p>";
 }
 
 function adjustImageName($name)

--- a/www/adminops
+++ b/www/adminops
@@ -2895,6 +2895,7 @@ else if (isset($_REQUEST['deletenews'])) {
     echo "</table>";
 } else if (isset($_REQUEST['markdownTest'])) {
     $parsedown = new Parsedown();
+    $parsedown->setUrlsLinked(false); // URLs linked are always good, so let's ignore changes due to this
     $result = mysqli_execute_query($db, "select id, gameid, review from reviews where review is not null and special is null");
     $matches = 0;
     $count = mysql_num_rows($result);


### PR DESCRIPTION
I mostly cooked this by trial and error.

To use it, login as admin, open dev tools, and go to http://localhost:8080/adminops?markdownTest

It will log a bunch of mismatching reviews. It finds that there are 13,545 reviews that are totally unaffected by adding Markdown support out of 14,989. (90%.)

To get to that point, I had to normalize the differences pretty aggressively.

1. On the server side, I'm stripping `\r` characters before passing them to Parsedown/fixDesc. Apparently a bunch of reviews have stray `\r` characters (not `\r\n`, and not in any obvious placement as if intended for paragraph breaks. The legacy system would eventually display those as spaces, but Parsedown thinks they're line breaks, and tries to turn them into `</p><p>` or `<br>` breaks.
2. On the client side, there are a lot of changes in insignificant whitespace, so I'm using JS to write the content to the DOM, then walking the DOM tree to find text nodes, trimming leading/trailing spaces, and converting multiple spaces into a single space.
3. I also normalized `<br><br>` into `</p><p>`.
4. And, for some reason, Parsedown seems to want to drop an empty `<p></p>` in various places; this is invisible in practice, so I'm stripping those out, too.

Clicking around a little, I found changes like these:

* **Single-line breaks that get merged away.** <https://ifdb.org/viewgame?id=ju778uv5xaswnlpl&review=864>

  > I have not finished the game(yet?). I went as far as the school gym...
  > But having all these pieces of stories with no real solid link is overwhelming to keep in mind. The only attractive thing is the writing style...
  > There would be only two or three storylines, it would be nice, and maybe there is only three, who knows? THIS is the problem. (I must say I play with gargoyle, so I don't have the colored interface.)
  > Giving the fact that playing itself is not really fun I think I will give up.
  > But something wants me to continue, something wants me to see all the pieces come together at the end...
  > It is like suffering a long run to get a promised ice cream... but I am beginning to wonder about the taste of the ice cream.

  Parsedown eats these single-line breaks and turns most of the review into a single paragraph.
  
* **Markdown-like syntax that was not intended to be Markdown.** <https://ifdb.org/viewgame?id=ywwlr3tpxnktjasd&review=851>

  > **Difficult game?**
  > 
  > Oh yes. I've played some difficult games before but none that come close to Varicella in terms of sheer, downright impossibility*.
  > 
  > \* Okay, maybe an exaggeration.
  
  This asterisk was intended to be a cute footnote; Parsedown turns it into a bullet.
  
  Or, another example. <https://ifdb.org/viewgame?id=5230wsgz1pgjfdgu&review=1677>

  > \>drop cigar
  > Which do you mean, the cigar or the cigar case?
  > 
  > \>cigar
  > Which do you mean, the cigar or the cigar case?
  
  Parsedown turns these into blockquotes.

* Markdown-like syntax that's improved by Parsedown, usually unlinked URLs that get turned into links, but occasionally bulleted lists or what have you.
