### PR TITLE
Use multiline transformation

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -2914,9 +2914,8 @@ else if (isset($_REQUEST['deletenews'])) {
     for ($i = 0; $i < $count; $i++) {
         $rec = mysql_fetch_array($result, MYSQL_ASSOC);
         $raw = $rec['review'];
-        $reviewMarkdown = normalizeSpoiler(fixDesc($parsedown->line($raw), FixDescSpoiler));
-        $reviewMarkdown = preg_replace('/<em>((?:.*?)<br>(?:\s*?))<\/em>/im', '*$1*', $reviewMarkdown);
-        $reviewLegacy = normalizeSpoiler(fixDesc($rec['review'], FixDescSpoiler));
+        $reviewMarkdown = normalizeSpoiler(fixDesc(parsedownMultilineText($raw), FixDescMarkdown));
+        $reviewLegacy = normalizeSpoiler(fixDesc($rec['review']));
         echo json_encode(["id" => $rec['id'], "gameid" => $rec['gameid'], "raw" => $rec['review'], "before" => $reviewLegacy, "after" => $reviewMarkdown]) . ",\n";
     }
     echo "];</script>\n";
@@ -2957,15 +2956,22 @@ else if (isset($_REQUEST['deletenews'])) {
     }
 
     function generateLineDiffHtml(beforeText, afterText, tuid, reviewId) {
-        const beforeLines = beforeText.split(/(<br>|\n)/i);
-        const afterLines = afterText.split(/(<br>|\n)/i);
+        let re = /(?:<p>|<p\/>|<\/p> *|<br> ?|\n)+/i;
+        const beforeLines = beforeText.split(re).filter(l => !!l.trim());
+        const afterLines = afterText.split(re).filter(l => !!l.trim());
         const maxLength = Math.max(beforeLines.length, afterLines.length);
 
         let html = `<h3><a href='/viewgame?id=${tuid}&review=${reviewId}'>${reviewId}</a></h3>\n`;
+        let match = true;
+        let normalizer = document.createElement('div');
 
         for (let i = 0; i < maxLength; i++) {
-            const beforeLine = beforeLines[i] !== undefined ? beforeLines[i] : '';
-            const afterLine = afterLines[i] !== undefined ? afterLines[i] : '';
+            const beforeLineText = (beforeLines[i] ?? '').trim();
+            const afterLineText = (afterLines[i] ?? '').trim();
+            normalizer.innerHTML = beforeLineText;
+            const beforeLine = normalizer.innerHTML;
+            normalizer.innerHTML = afterLineText;
+            const afterLine = normalizer.innerHTML;
 
             let lineBeforeHtml = '';
             let lineAfterHtml = '';
@@ -2973,6 +2979,8 @@ else if (isset($_REQUEST['deletenews'])) {
             if (beforeLine === afterLine) {
                 continue;
             } else {
+                match = false;
+                console.log({beforeLine, afterLine});
                 const commonPrefix = findLongestCommonPrefix(beforeLine, afterLine);
                 lineBeforeHtml += commonPrefix;
                 lineAfterHtml += commonPrefix;
@@ -3005,7 +3013,7 @@ else if (isset($_REQUEST['deletenews'])) {
         }
         let div = document.createElement('div');
         div.innerHTML = html;
-        return div;
+        return {div, match};
     }
     
     function normalizeSpoiler(text) {
@@ -3018,15 +3026,21 @@ else if (isset($_REQUEST['deletenews'])) {
 
     for (let i = 0; i < window.reviews.length; i++) {
         const review = window.reviews[i];
-        let before = normalizeSpoiler(review.before);
+        let before = normalizeSpoiler("<p>" + review.before);
         let after = normalizeSpoiler(review.after);
         if (before == after) {
             matches++;
         } else {
-            const mismatch = { i, review, befor: before, after };
+            let {div, match}  = generateLineDiffHtml(before, after, review.gameid, review.id)
+            if (match) {
+                console.log('match');
+                matches++;
+                continue;
+            }
+            const mismatch = { i, id: review.id, review, befor: before, after };
             console.log(mismatch);
             window.mismatches.push(mismatch);
-            window.output.appendChild(generateLineDiffHtml(before, after, review.gameid, review.id));
+            window.output.appendChild(div);
         }
     }
     console.log({matches, count: window.reviews.length});

--- a/www/allreviews
+++ b/www/allreviews
@@ -202,6 +202,7 @@ if ($errMsg) {
              null) as embargodate,
            reviews.special as special,
            date_format(greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as publicationdatefmt,
+           reviews.moddate as moddate,
            date_format(greatest(reviews.moddate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as moddatefmt,
            sum(reviewvotes.vote = 'Y' and ifnull(rvu.sandbox, 0) in $sandbox) as helpful,
            sum(reviewvotes.vote = 'N' and ifnull(rvu.sandbox, 0) in $sandbox) as unhelpful,

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -770,7 +770,7 @@ function showNewItemsRSS($db, $showcnt)
                 }
                 $title .= $stars;
             }
-            $desc = fixDesc($parsedown->line($r['review']), FixDescSpoiler | FixDescRSS);
+            $desc = fixDesc(parsedownMultilineText($r['review']), FixDescSpoiler | FixDescRSS | FixDescMarkdown);
             $link = get_root_url() . "viewgame?id={$r['gameid']}"
                     . "&review={$r['id']}";
             $pubDate = $r['d'];

--- a/www/review
+++ b/www/review
@@ -285,7 +285,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_REQUEST['delete'])) {
     echo "<b>$title</b>, by $author<br>"
         . showStars($oldrating)
         . "<b>" . htmlspecialcharx($oldsummary) . "</b><br>"
-        . fixDesc($parsedown->line($oldreview), FixDescSpoiler | FixDescMarkdown);
+        . fixDesc(parsedownMultilineText($oldreview), FixDescSpoiler | FixDescMarkdown);
 
     echo "</div><form name=\"confirmdelete\" method=\"post\" "
         . "action=\"review?id=$id&userid=$userid\">"
@@ -300,7 +300,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_REQUEST['delete'])) {
     $summary = get_req_data("summary");
     $reviewbody = get_req_data("reviewbody");
     $oldVersion = get_req_data("oldVersion");
-    $parsedReview = $parsedown->line($reviewbody);
+    $parsedReview = $parsedownMultilineText($reviewbody);
     $special = get_req_data("special");
     $embargoDate = get_req_data("embargoDate");
     $tags = get_req_data("tags");
@@ -389,7 +389,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $rating = get_req_data("rating");
     $summary = get_req_data("summary");
     $reviewbody = get_req_data("reviewbody");
-    $parsedReview = $parsedown->line($reviewbody);
+    $parsedReview = parsedownMultilineText($reviewbody);
     $special = get_req_data("special");
     $embargoDate = get_req_data("embargoDate");
     $tags = get_req_data("tags");

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -15,7 +15,6 @@
 // make sure we process any persistent login state
 include_once "login-persist.php";
 include_once "commentutil.php";
-require_once 'vendor/autoload.php';
 
 // get the query given a WHERE condition
 function getReviewQuery($db, $where)
@@ -252,7 +251,6 @@ define("SHOWREVIEW_COLLAPSELONG", 0x0010);
 
 function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 {
-    $parsedown = new Parsedown();
     global $specialCodes;
 
     // note whether or not they want voting and/or comment controls
@@ -272,7 +270,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $qreviewid = mysql_real_escape_string($reviewid, $db);
     $rating = $rec['rating'];
     $summary = htmlspecialcharx($rec['summary']);
-    $review = fixDesc($parsedown->line($rec['review']), FixDescSpoiler | FixDescMarkdown);
+    $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescMarkdown);
     $publicationdate = $rec['publicationdatefmt'];
     $moddate = $rec['moddatefmt'];
     $lastupdateFootnote = null;

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -61,7 +61,7 @@ function getReviewQuery($db, $where)
     // as formatted for display, also to faciliate sorting.
     return
         "select sql_calc_found_rows
-           reviews.id as reviewid, rating, summary, review,
+           reviews.id as reviewid, rating, summary, review, moddate,
            date_format(greatest(reviews.moddate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as moddatefmt,
            greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))) as publicationdate,
            date_format(greatest(reviews.createdate, ifnull(embargodate, cast(0 as datetime))), '%M %e, %Y') as publicationdatefmt,
@@ -270,16 +270,20 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $qreviewid = mysql_real_escape_string($reviewid, $db);
     $rating = $rec['rating'];
     $summary = htmlspecialcharx($rec['summary']);
-    $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescMarkdown);
+    if (strcmp($rec['moddate'], '2025-08-26') < 0) {
+        $review = fixDesc($rec['review'], FixDescSpoiler);
+    } else {
+        $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescMarkdown);
+    }
     $publicationdate = $rec['publicationdatefmt'];
-    $moddate = $rec['moddatefmt'];
+    $moddatefmt = $rec['moddatefmt'];
     $lastupdateFootnote = null;
-    if ($moddate && $publicationdate != $moddate) {
+    if ($moddatefmt && $publicationdate != $moddatefmt) {
         // Rating-only review
         if ($review == "") {
-            $publicationdate .= " (last edited on $moddate)";
+            $publicationdate .= " (last edited on $moddatefmt)";
         } else {
-            $lastupdateFootnote = "This review was last edited on $moddate";
+            $lastupdateFootnote = "This review was last edited on $moddatefmt";
             $publicationdate .= "<span title=\"$lastupdateFootnote\">*</span>";
         }
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -1575,8 +1575,8 @@ if ($embargoCnt > 0)
         // show other (non-editorial) special reviews
         $result = mysql_query(
             "select reviews.id as reviewid,
-               rating, summary, review,
-               date_format(moddate, '%M %e, %Y') as moddate,
+               rating, summary, review, moddate,
+               date_format(moddate, '%M %e, %Y') as moddatefmt,
                specialreviewers.id as special,
                specialreviewers.name as specialname,
                users.id as userid, users.name as username, location


### PR DESCRIPTION
This PR uses `parsedown->text` instead of `parsedown->line`, so we get all the powers of Markdown. The adminops test now shows 14040 out of 14990 matches which is still pretty manageable. (It's 14040 matches if I use `setUrlsLinked(false)`, which means that 136 of those mismatches are purely due to unlinked URLs.)

A lot of the magic is happening in `function parsedownMultilineText` in `util.php`, where I do some weird find-and-replace stuff to make single-line breaks work as intended.

Tested with:

```
Hello this is the **Parsedown** implementation. _Test_ formatting!

* Also does bullet points
1. And numbers!

(It didn't parse at first cus I didn't check the checkbox.)

Converted automatically to HTML.

this
is
a
test!
```