### PR TITLE
Remove stray `if ($specials)`

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -1126,7 +1126,7 @@ function fixDesc($desc, $specials = 0)
                 $ofs += 4;
             } else if (strncasecmp($therest, "quot;", 5) == 0) {
                 $ofs += 5;
-            } else if ($specials) {
+            } else {
                 // not recognized - make it an explicit &amp;
                 $desc = substr_replace($desc, "&amp;", $ofs, 1);
                 $ofs += 4;


### PR DESCRIPTION
In the main branch prior to work on Parsedown, this was a simple `else`. In fe35272b we experimented with making it `else if ($specials & !FixDescMarkdown)`, but when we removed `FixDescMarkdown` in 3b8b9f03 we didn't revert the rest of the line.

This commit makes a simple `fixDesc($txt)` with no `$specials` convert unrecognized entities to `&amp;`, as it used to.