### PR TITLE
Remove another stray `if ($specials)`

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -1135,9 +1135,7 @@ function fixDesc($desc, $specials = 0)
 
         case '"':
             // convert to &quot;
-            if ($specials) {
-                $desc = substr_replace($desc, "&quot;", $ofs, 1);
-            }
+            $desc = substr_replace($desc, "&quot;", $ofs, 1);
             break;
 
         case "'":


### PR DESCRIPTION
In the main branch prior to work on Parsedown, we would always convert quotes to `&quot;` in this case. In fe35272b we experimented with making it `if ($specials & !FixDescMarkdown)`, but when we removed `FixDescMarkdown` in 3b8b9f03 we didn't revert the rest of the `if`.

This commit makes a simple `fixDesc($txt)` with no `$specials` convert quotes to `&quot;`, as it used to.