### PR TITLE
Support but demote h1 h2 h3 headings

### DIFF
--- a/www/review
+++ b/www/review
@@ -282,7 +282,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_REQUEST['delete'])) {
     echo "<b>$title</b>, by $author<br>"
         . showStars($oldrating)
         . "<b>" . htmlspecialcharx($oldsummary) . "</b><br>"
-        . fixDesc(parsedownMultilineText($oldreview), FixDescSpoiler);
+        . fixDesc(parsedownMultilineText($oldreview), FixDescSpoiler | FixDescDemoteHeadings);
 
     echo "</div><form name=\"confirmdelete\" method=\"post\" "
         . "action=\"review?id=$id&userid=$userid\">"
@@ -461,7 +461,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             .   "by <a href=\"showuser?id=$userid\">$username</a>"
             . ($userloc != "" ? " ($userloc)" : "")
             . "</span><br>"
-            . fixDesc($parsedReview, FixDescSpoiler);
+            . fixDesc($parsedReview, FixDescSpoiler | FixDescDemoteHeadings);
 
         if (trim($tags) != "")
             echo "<p><b>Tags:</b> " . htmlspecialcharx($tags);

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -271,9 +271,9 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $rating = $rec['rating'];
     $summary = htmlspecialcharx($rec['summary']);
     if (strcmp($rec['moddate'], '2025-08-26') < 0) {
-        $review = fixDesc($rec['review'], FixDescSpoiler);
+        $review = fixDesc($rec['review'], FixDescSpoiler | FixDescDemoteHeadings);
     } else {
-        $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler);
+        $review = fixDesc(parsedownMultilineText($rec['review']), FixDescSpoiler | FixDescDemoteHeadings);
     }
     $publicationdate = $rec['publicationdatefmt'];
     $moddatefmt = $rec['moddatefmt'];

--- a/www/util.php
+++ b/www/util.php
@@ -766,6 +766,7 @@ function spoilerWarningScript()
 define("FixDescSpoiler", 0x0001);
 define("FixDescRSS", 0x0002);
 define("FixDescIfic", 0x0004);
+define("FixDescDemoteHeadings", 0x0008);
 function fixDesc($desc, $specials = 0)
 {
     $foundSpoiler = false;
@@ -793,6 +794,7 @@ function fixDesc($desc, $specials = 0)
               'i', 'b', 'u', 'strong', 'em', 'hr',
               'big', 'small', 'tt', 'sup', 'sub',
               'cite', 'blockquote', 'code', 'pre',
+              'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
               'ul', 'ol', 'li', 'dl', 'dt', 'dd'), 1);
 
     // tags that trigger explicit line control mode
@@ -958,6 +960,16 @@ function fixDesc($desc, $specials = 0)
                     }
 
                 } else if (isset($allowedTags[$tagName])) {
+
+                    // If we're demoting headings, convert <h1> to <h4>, <h2> to <h5> and so on
+                    if (($specials & FixDescDemoteHeadings) && preg_match("/^h(\d)$/", $tagName, $matches)) {
+                        $level = min(6, ((int)$matches[1]) + 3);
+                        if ($isClose) {
+                            $desc = substr_replace($desc, "</h$level>", $ofs, $tagLen);
+                        } else {
+                            $desc = substr_replace($desc, "<h$level>", $ofs, $tagLen);
+                        }
+                    }
 
                     // it's an allowed tag - keep it
                     $ofs = $gt;


### PR DESCRIPTION
We want to let users add Markdown headings, but we don't want people to drop random `<h1>` elements in the reviews section, which would break the heading tree (which screenreaders use for navigation).

So, we're "allowing" `<h1>` tags, but "demoting" them into `<h4>` tags when displaying them. `<h2>` tags get demoted to `<h5>` tags, and all other header tags get demoted to `<h6>` tags.